### PR TITLE
Request authentication improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# 1.9.8
+
+## Bug fix
+
+- Request now internally normalizes header names to avoid erroneous addition of 'Authorization'
+  header if one is already present, albeit with different casing.
+
 # 1.9.7
 
 ## Change

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 - Request now internally normalizes header names to avoid erroneous addition of 'Authorization'
   header if one is already present, albeit with different casing.
+- For requests with expired provided authorization header (on-behalf auth), no token refresh is
+  attempted to prevent an infinite loop.
 
 # 1.9.7
 

--- a/lib/graph_conn/connection_manager.ex
+++ b/lib/graph_conn/connection_manager.ex
@@ -78,17 +78,23 @@ defmodule GraphConn.ConnectionManager do
     |> GenServer.cast({:open_ws_connection, target_api})
   end
 
-  defp _execute_rest(base_name, target_api, request, opts) do
+  defp _execute_rest(base_name, target_api, request, opts, attempt \\ 1) do
     case GraphRestCalls.execute(base_name, target_api, request, opts) do
-      {:ok, %Response{code: 401}} ->
-        Logger.warning("Token has unexpectedly expired. Refreshing token and retrying call...")
+      {:ok, %Response{code: 401}} = result ->
+        # Don't refresh token if request is made on behalf of another entity or if we've already
+        # tried refreshing once, to avoid infinite loop in case of other auth issues.
+        if Request.on_behalf_auth?(request) or attempt > 1 do
+          result
+        else
+          Logger.warning("Token has unexpectedly expired. Refreshing token and retrying call...")
 
-        :ok =
-          base_name
-          |> _name()
-          |> GenServer.call(:refresh_token)
+          :ok =
+            base_name
+            |> _name()
+            |> GenServer.call(:refresh_token)
 
-        _execute_rest(base_name, target_api, request, opts)
+          _execute_rest(base_name, target_api, request, opts, attempt + 1)
+        end
 
       other ->
         other

--- a/lib/graph_conn/graph_rest_calls.ex
+++ b/lib/graph_conn/graph_rest_calls.ex
@@ -151,9 +151,9 @@ defmodule GraphConn.GraphRestCalls do
         end
 
       request
-      |> _inject_namespace(namespace)
-      |> _normalize_request_headers()
-      |> _inject_token(token)
+      |> Request.normalize_headers()
+      |> Request.set_namespace(namespace)
+      |> Request.set_default_auth(token)
       |> _shoot(base_name, config, opts)
       |> _process_response()
     end
@@ -169,27 +169,6 @@ defmodule GraphConn.GraphRestCalls do
       version -> {:ok, version}
     end
   end
-
-  @spec _inject_namespace(Request.t(), String.t()) :: Request.t()
-  defp _inject_namespace(%Request{path: path} = request, namespace),
-    do: %Request{request | path: namespace <> path}
-
-  @spec _normalize_request_headers(Request.t()) :: Request.t()
-  defp _normalize_request_headers(%Request{headers: headers} = request),
-    do: %Request{
-      request
-      | headers:
-          Map.new(headers, fn {name, value} ->
-            {name |> to_string() |> String.downcase(), value}
-          end)
-    }
-
-  @spec _inject_token(Request.t(), nil | String.t()) :: Request.t()
-  defp _inject_token(%Request{} = request, nil),
-    do: request
-
-  defp _inject_token(%Request{headers: headers} = request, token),
-    do: %Request{request | headers: Map.put_new(headers, "authorization", "Bearer " <> token)}
 
   defp _shoot(%Request{} = request, base_name, config, opts \\ []) do
     timeout = Keyword.get(opts, :timeout, Keyword.get(config, :timeout, 5_000))

--- a/lib/graph_conn/graph_rest_calls.ex
+++ b/lib/graph_conn/graph_rest_calls.ex
@@ -152,6 +152,7 @@ defmodule GraphConn.GraphRestCalls do
 
       request
       |> _inject_namespace(namespace)
+      |> _normalize_request_headers()
       |> _inject_token(token)
       |> _shoot(base_name, config, opts)
       |> _process_response()
@@ -173,12 +174,22 @@ defmodule GraphConn.GraphRestCalls do
   defp _inject_namespace(%Request{path: path} = request, namespace),
     do: %Request{request | path: namespace <> path}
 
+  @spec _normalize_request_headers(Request.t()) :: Request.t()
+  defp _normalize_request_headers(%Request{headers: headers} = request),
+    do: %Request{
+      request
+      | headers:
+          Map.new(headers, fn {name, value} ->
+            {name |> to_string() |> String.downcase(), value}
+          end)
+    }
+
   @spec _inject_token(Request.t(), nil | String.t()) :: Request.t()
   defp _inject_token(%Request{} = request, nil),
     do: request
 
   defp _inject_token(%Request{headers: headers} = request, token),
-    do: %Request{request | headers: Map.put_new(headers, "Authorization", "Bearer " <> token)}
+    do: %Request{request | headers: Map.put_new(headers, "authorization", "Bearer " <> token)}
 
   defp _shoot(%Request{} = request, base_name, config, opts \\ []) do
     timeout = Keyword.get(opts, :timeout, Keyword.get(config, :timeout, 5_000))

--- a/lib/graph_conn/request.ex
+++ b/lib/graph_conn/request.ex
@@ -3,7 +3,9 @@ defmodule GraphConn.Request do
   Structure of request used as a parameter in MyConn.execute/3.
   """
 
-  @type t() :: %__MODULE__{
+  alias __MODULE__, as: Request
+
+  @type t() :: %Request{
           method: :get | :post | :put | :patch | :head | :options,
           headers: map(),
           path: String.t(),
@@ -12,4 +14,55 @@ defmodule GraphConn.Request do
         }
 
   defstruct method: :get, path: "", query_params: %{}, body: nil, headers: %{}
+
+  @doc """
+  Normalizes the header names in the request to lowercase strings for consistent handling.
+  """
+  @spec normalize_headers(Request.t()) :: Request.t()
+  def normalize_headers(%Request{headers: headers} = request),
+    do: %Request{
+      request
+      | headers:
+          Map.new(headers, fn {name, value} ->
+            {_normalize_header_name(name), value}
+          end)
+    }
+
+  defp _normalize_header_name(name) when is_atom(name),
+    do: name |> to_string() |> String.downcase(:ascii)
+
+  defp _normalize_header_name(name) when is_binary(name),
+    do: String.downcase(name, :ascii)
+
+  @doc """
+  Prefixes the request path with the given namespace if not already present.
+  """
+  @spec set_namespace(Request.t(), String.t()) :: Request.t()
+  def set_namespace(%Request{path: path} = request, namespace),
+    do: %Request{request | path: namespace <> path}
+
+  @doc """
+  Sets the "authorization" header to "Bearer <token>" if the header is not already present, using
+  the provided token.
+
+  Does nothing if token is `nil`.
+  """
+  @spec set_default_auth(Request.t(), nil | String.t()) :: Request.t()
+  def set_default_auth(%Request{} = request, nil),
+    do: request
+
+  def set_default_auth(%Request{headers: headers} = request, token),
+    do: %Request{request | headers: Map.put_new(headers, "authorization", "Bearer " <> token)}
+
+  @doc """
+  Returns whether the request is authenticated on behalf of another entity by checking for the
+  presence of an "authorization" header.
+
+  Note that if this is called after `set_default_auth/2`, it will also return `true` for requests
+  that are not actually on-behalf auth, but simply have a token set.
+  """
+  @spec on_behalf_auth?(Request.t()) :: boolean()
+  def on_behalf_auth?(%Request{headers: headers}),
+    do:
+      Enum.any?(headers, fn {name, _value} -> _normalize_header_name(name) == "authorization" end)
 end

--- a/lib/graph_conn/test/mock_router.ex
+++ b/lib/graph_conn/test/mock_router.ex
@@ -80,6 +80,17 @@ defmodule GraphConn.Test.MockRouter do
     _success(conn, GraphConn.Mock.get_applicabilities())
   end
 
+  # Echos back collected map of request headers
+  get "/api/:_/action/test-only/headers" do
+    headers =
+      conn.req_headers
+      |> Enum.reduce(%{}, fn {name, value}, acc ->
+        Map.update(acc, name, [value], fn values -> values ++ [value] end)
+      end)
+
+    _success(conn, headers)
+  end
+
   defp _apis do
     %{
       "action" => %{

--- a/mix.exs
+++ b/mix.exs
@@ -6,7 +6,7 @@ defmodule GraphConn.MixProject do
   def project do
     [
       app: :graph_conn,
-      version: "1.8.0",
+      version: "1.9.8",
       elixir: "~> 1.17",
       start_permanent: true,
       test_coverage: [tool: ExCoveralls],

--- a/test/graph_conn_test.exs
+++ b/test/graph_conn_test.exs
@@ -103,10 +103,30 @@ defmodule GraphConnTest do
       true = :ets.insert(TestConn, {:token, "wrong_token"})
 
       request = %Request{
-        path: "capabilities"
+        path: "app/some_dummy_config/handlers"
       }
 
-      assert {:ok, %Response{body: %{}}} = TestConn.execute(:action, request)
+      assert {:ok, %Response{body: [%{}]}} = TestConn.execute(:action, request)
+
+      # Assert that token has been refreshed
+      assert [{:token, "action_invoker"}] == :ets.lookup(TestConn, :token)
+    end
+
+    test "doesn't refresh token and retry call if on behalf auth is used" do
+      # Setting the token to an invalid value is per-se not relevant, but we need to make sure
+      # that no refresh is performed.
+      :ets.insert(TestConn, {:token, "token_wont_be_refreshed"})
+
+      request = %Request{
+        path: "app/some_dummy_config/handlers",
+        headers: %{authorization: "wrong_token"}
+      }
+
+      # Assert that this doesn't cause infinite loop and returns the correct response
+      assert {:ok, %Response{code: 401}} = TestConn.execute(:action, request)
+
+      # Assert that token has *not* been refreshed
+      assert [{:token, "token_wont_be_refreshed"}] == :ets.lookup(TestConn, :token)
     end
 
     test "opens ws connection on demand" do

--- a/test/graph_conn_test.exs
+++ b/test/graph_conn_test.exs
@@ -89,6 +89,16 @@ defmodule GraphConnTest do
       assert {:ok, %Response{body: %{}}} = TestConn.execute(:action, request)
     end
 
+    test "does not duplicate authorization header when request already has one with different casing" do
+      request = %Request{
+        path: "test-only/headers",
+        headers: %{"authorization" => "Bearer override_token"}
+      }
+
+      assert {:ok, %Response{body: body}} = TestConn.execute(:action, request)
+      assert ["Bearer override_token"] == body["authorization"]
+    end
+
     test "refreshes token and retries call if token is expired" do
       true = :ets.insert(TestConn, {:token, "wrong_token"})
 


### PR DESCRIPTION
As discussed, request headers are now lowercased before the token is injected to avoid sending multiple authorization headers.

Also, I've fixed the issue with ConnectionManager going into an infinite loop when attempting to refresh user-provided auth tokens.